### PR TITLE
Add Tides Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -37,7 +37,7 @@ public class TidesController {
         @Parameter(name="station", description="station id", example="9411340") @RequestParam String station
         ) throws JsonProcessingException {
         log.info("getTides: begin_date={} end_date={} station={}", begin_date, end_date, station);
-        String result = tidesQueryService.getJSON(station, begin_date, end_date);
+        String result = tidesQueryService.getJSON(begin_date, end_date, station);
         return ResponseEntity.ok().body(result);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -2,8 +2,42 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Tide info from NOAA")
+@Slf4j
 @RestController
+@RequestMapping("/api/tides")
 public class TidesController {
 
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @Operation(summary = "Get tides for a certain station", description = "JSON return format documented here: https://api.tidesandcurrents.noaa.gov/api/prod/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+        @Parameter(name="begin_date", description="begin date", example="20230815") @RequestParam String begin_date,
+        @Parameter(name="end_date", description="end date", example="20230816") @RequestParam String end_date,
+        @Parameter(name="station", description="station id", example="9411340") @RequestParam String station
+        ) throws JsonProcessingException {
+        log.info("getTides: begin_date={} end_date={} station={}", begin_date, end_date, station);
+        String result = tidesQueryService.getJSON(station, begin_date, end_date);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    TidesQueryService mockTidesQueryService;
+
+
+    @Test
+    public void test_getTides() throws Exception {
+    
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String begin_date = "20230815";
+        String end_date = "20230816";
+        String station = "9411340";
+        when(mockTidesQueryService.getJSON(eq(station),eq(begin_date),eq(end_date))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/tides/get?begin_date=%s&end_date=%s&station=%s",begin_date,end_date,station);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -45,7 +45,7 @@ public class TidesControllerTests {
         String begin_date = "20230815";
         String end_date = "20230816";
         String station = "9411340";
-        when(mockTidesQueryService.getJSON(eq(station),eq(begin_date),eq(end_date))).thenReturn(fakeJsonResult);
+        when(mockTidesQueryService.getJSON(eq(begin_date),eq(end_date),eq(station))).thenReturn(fakeJsonResult);
 
         String url = String.format("/api/tides/get?begin_date=%s&end_date=%s&station=%s",begin_date,end_date,station);
 


### PR DESCRIPTION
In this PR, we add an endpoint `/api/tides/get` that can be used to get information about the tides detected by a particular station.

The dev link is http://team01-wenxuanxu-dev.dokku-03.cs.ucsb.edu/swagger-ui/index.html#/Tide%20info%20from%20NOAA/getTides

Closes #10